### PR TITLE
Add some optional parameters and select dest to main rsyslog file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,3 +88,6 @@ rsyslog_imuxsock_syssock: no
 #   - gnutls
 #   - elastisearch
 rsyslog_features: []
+
+# Default destination of rsyslog config file
+rsyslog_dest_conf_file: "/etc/rsyslog.conf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: configuring default rsyslog
   ansible.builtin.template:
     src: "{{ rsyslog_config_file_format }}_rsyslog.conf.j2"
-    dest: /etc/rsyslog.conf
+    dest: "{{ rsyslog_dest_conf_file }}"
     mode: "0644"
   when:
     - rsyslog_deploy_default_config

--- a/templates/advanced_rsyslog.conf.j2
+++ b/templates/advanced_rsyslog.conf.j2
@@ -48,8 +48,17 @@ module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
 #
 # Set the default permissions for all log files.
 #
+{% if rsyslog_fileowner is defined %}
+$FileOwner {{ rsyslog_fileowner }}
+{% endif %}
+{% if rsyslog_filegroup is defined %}
+$FileGroup {{ rsyslog_filegroup }}
+{% endif %}
 $FileCreateMode {{ rsyslog_filecreatemode }}
 $DirCreateMode {{ rsyslog_dircreatemode }}
+{% if rsyslog_umask is defined %}
+$Umask {{ rsyslog_umask }}
+{% endif %}
 
 #
 # Where to place spool and state files

--- a/templates/legacy_rsyslog.conf.j2
+++ b/templates/legacy_rsyslog.conf.j2
@@ -38,8 +38,17 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 #
 # Set the default permissions for all log files.
 #
+{% if rsyslog_fileowner is defined %}
+$FileOwner {{ rsyslog_fileowner }}
+{% endif %}
+{% if rsyslog_filegroup is defined %}
+$FileGroup {{ rsyslog_filegroup }}
+{% endif %}
 $FileCreateMode {{ rsyslog_filecreatemode }}
 $DirCreateMode {{ rsyslog_dircreatemode }}
+{% if rsyslog_umask is defined %}
+$Umask {{ rsyslog_umask }}
+{% endif %}
 
 #
 # Where to place spool and state files


### PR DESCRIPTION
Allows you to choose the destination of the main configuration file. (Useful when the rsyslog.conf is a symbolic link to another file)
Added some optional parameters for the creation of rights on log files