### PR TITLE
Comment out TraditionalFileFormat if false

### DIFF
--- a/templates/advanced_rsyslog.conf.j2
+++ b/templates/advanced_rsyslog.conf.j2
@@ -67,7 +67,7 @@ $InputTCPServerBindRuleset {{ rsyslog_input_tcp_rule }}
 # Use traditional timestamp format.
 # To enable high precision timestamps, comment out the following line.
 #
-module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+{{ '' if rsyslog_traditional_file_format else '#' }}module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
 
 #
 # Set the default permissions for all log files.


### PR DESCRIPTION
---
name: Pull request
about: TraditionalFileFormat variable is not taken into account

---

**Describe the change**
Adding code to comment out the line in rsyslog.conf if var is false

**Testing**
set var to true: line is not commented out
set var to false: line is commented out
